### PR TITLE
Add stream link to calendar event

### DIFF
--- a/barcampcanterbury.com/index.html
+++ b/barcampcanterbury.com/index.html
@@ -116,6 +116,7 @@
 					<span class="location">Canterbury, Kent, UK</span>
 					<span class="organizer_email">allan@barcampcanterbury.com</span>
 					<span class="alarm_reminder">1440</span>
+					<span class="description">YouTube livestream: https://www.youtube.com/channel/UCVAXGA8Y9bfdypx160rSJgw<br />Facebook livestream: https://www.facebook.com/events/221385545794285</span>
 				</div>
 
 			</div>


### PR DESCRIPTION
Adds the two stream links provided on the website as a description to the calendar event.

I left them as bare URLs, because even though the documentation says that often simple HTML is allowed there, I am not sure if that includes links (probably does) and in the case where HTML is unsupported it "converts to readable text" but I am not sure what that means for <a> elements, making the rendering unpredictable. Hence simple plain-text URLs

I also dropped the parameters from the facebook one, to make it shorter